### PR TITLE
Fix verified being submitted to db as string

### DIFF
--- a/server/src/dbms.py
+++ b/server/src/dbms.py
@@ -671,7 +671,7 @@ class DBMS():
                 "{steam_id}", "{time_id}", {time.time()},
                 "{current_world}", "{trail_name}",
                 "{str(being_monitored)}", "{bike_type}",
-                "False", {starting_speed}, "{version}", {penalty}, "{verified}"
+                "False", {starting_speed}, "{version}", {penalty}, {verified}
             )
             ''',
             write=True


### PR DESCRIPTION
This is what was causing verified times to not show in leaderboards.